### PR TITLE
Unhug leading and trailing braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,6 @@ Note that functions with starargs (`*args`), kwargs (`**kwargs`), or python 3
 keyword-only arguments (`..., *, ...`) cannot have a trailing comma due to it
 being a syntax error.
 
-
-## Planned features
-
 ### unhug trailing paren
 
 ```diff
@@ -147,4 +144,17 @@ being a syntax error.
 +    arg1,
 +    arg2,
 +)
+```
+
+## Planned features
+
+### Match closing brace indentation
+
+```diff
+ x = [
+     1,
+     2,
+     3,
+-    ]
++]
 ```

--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -297,6 +297,130 @@ def test_fixes_defs(src, expected):
     assert _fix_src(src, py35_plus=False) == expected
 
 
+@pytest.mark.parametrize(
+    'src',
+    (
+        'f(x, y, z)',
+        'f(\n'
+        '    x,\n'
+        ')',
+        # Single argument, don't unhug
+        'f((\n'
+        '    1, 2, 3,\n'
+        '))',
+        'f([\n'
+        '    1, 2, 3,\n'
+        '])',
+    ),
+)
+def test_noop_unhugs(src):
+    assert _fix_src(src, py35_plus=False) == src
+
+
+@pytest.mark.parametrize(
+    ('src', 'expected'),
+    (
+        (
+            'f(\n'
+            '    a)',
+
+            'f(\n'
+            '    a,\n'
+            ')',
+        ),
+        (
+            'f(a,\n'
+            '  b,\n'
+            ')',
+
+            'f(\n'
+            '    a,\n'
+            '    b,\n'
+            ')',
+        ),
+        (
+            'f(a,\n'
+            '  b,\n'
+            '  c)',
+
+            'f(\n'
+            '    a,\n'
+            '    b,\n'
+            '    c,\n'
+            ')',
+        ),
+        # if there's already a trailing comma, don't add a new one
+        (
+            'f(\n'
+            '    a,)',
+
+            'f(\n'
+            '    a,\n'
+            ')',
+        ),
+        (
+            'with a(\n'
+            '    b,\n'
+            '    c):\n'
+            '    pass',
+
+            'with a(\n'
+            '    b,\n'
+            '    c,\n'
+            '):\n'
+            '    pass',
+        ),
+        (
+            'if True:\n'
+            '    with a(\n'
+            '        b,\n'
+            '        c):\n'
+            '        pass',
+
+            'if True:\n'
+            '    with a(\n'
+            '        b,\n'
+            '        c,\n'
+            '    ):\n'
+            '        pass',
+        ),
+        (
+            "{'foo': 'bar',\n"
+            " 'baz':\n"
+            '    {\n'
+            "       'id': 1,\n"
+            ' },\n'
+            ' }',
+
+            # TODO: need to adjust trailing braces
+            '{\n'
+            "    'foo': 'bar',\n"
+            "    'baz':\n"
+            '       {\n'
+            "          'id': 1,\n"
+            '    },\n'
+            '    }',
+        ),
+        (
+            'f(g(\n'
+            '      a,\n'
+            '  ),\n'
+            '  1,\n'
+            ')',
+
+            'f(\n'
+            '    g(\n'
+            '        a,\n'
+            '    ),\n'
+            '    1,\n'
+            ')',
+        ),
+    ),
+)
+def test_fix_unhugs(src, expected):
+    assert _fix_src(src, py35_plus=False) == expected
+
+
 def test_main_trivial():
     assert main(()) == 0
 


### PR DESCRIPTION
CC @chriskuehl 

This makes a best effort to reindent in the opening hug case.  There's some oddities that aren't perfect, (they're pretty unlikely and hopefully will get noticed / fixed by some other tool such as autopep8).

I ran it against pre-commit/pre-commit and this was the diff generated (vs output against 0.3.0) (without involving autopep8):

```diff
--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -86,8 +86,10 @@ def _do_run(cap_out, repo, args, environ={}, config_file=C.CONFIG_FILE):
     return ret, printed
 
 
-def _test_run(cap_out, repo, opts, expected_outputs, expected_ret, stage,
-              config_file=C.CONFIG_FILE):
+def _test_run(
+    cap_out, repo, opts, expected_outputs, expected_ret, stage,
+    config_file=C.CONFIG_FILE,
+):
     if stage:
         stage_a_file()
     args = _get_opts(**opts)
@@ -571,8 +573,10 @@ def test_lots_of_files(mock_out_store_directory, tempdir_factory):
 
 
 @pytest.mark.parametrize(
-    ('hook_stage', 'stage_for_first_hook', 'stage_for_second_hook',
-     'expected_output'),
+    (
+        'hook_stage', 'stage_for_first_hook', 'stage_for_second_hook',
+        'expected_output',
+    ),
     (
         ('push', ['commit'], ['commit'], [b'', b'']),
         ('push', ['commit', 'push'], ['commit', 'push'],
```