### PR TITLE
Fix cases for more than one argument

### DIFF
--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -423,6 +423,30 @@ def test_noop_unhugs(src):
             '    *args\n'
             ')',
         ),
+        (
+            '{"foo": a[0],\n'
+            ' "bar": a[1]}',
+
+            '{\n'
+            '    "foo": a[0],\n'
+            '    "bar": a[1],\n'
+            '}',
+        ),
+        (
+            'x = (f(\n'
+            '    a,\n'
+            '), f(\n'
+            '    a,\n'
+            '))',
+
+            'x = (\n'
+            '    f(\n'
+            '        a,\n'
+            '    ), f(\n'
+            '        a,\n'
+            '    ),\n'
+            ')',
+        ),
     ),
 )
 def test_fix_unhugs(src, expected):


### PR DESCRIPTION
This fixes a couple of things actually:

### zero-width indents are now properly indented:
```python
[f(
    x,
), f(
    x,
)]
```
becomes
```python
[
    f(
        x,
    ), f(
        x,
    ),
]
```

### tuples that start with a function call are now properly unhugged

the ast points at the first argument for tuples, an `elif` was changed to an `if` -- *fixd*

### multi-argument things that ended in a brace are now unhugged

previously they were being excluded by my naive approximation of a single argument