### PR TITLE
Remove automatic py35+ syntax detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ This has the following benefits:
 
 ### trailing commas for function calls with unpackings
 
-If `--py35-plus` is passed (or python3.5+ syntax is automatically detected),
-`add-trailing-comma` will also perform the following change:
+If `--py35-plus` is passed, `add-trailing-comma` will also perform the
+following change:
 
 ```diff
  x(

--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -84,24 +84,6 @@ def test_py35_plus_rewrite():
     )
 
 
-@xfailif_lt_py35
-@pytest.mark.parametrize(
-    'syntax',
-    (
-        '(1, 2, *a)\n',
-        '[1, 2, *a]\n',
-        '{1, 2, *a}\n',
-        '{1: 2, **k}\n',
-        'y(*args1, *args2)\n',
-        'y(**kwargs1, **kwargs2)\n',
-    ),
-)
-def test_auto_detected_py35_plus_rewrite(syntax):
-    src = syntax + 'x(\n    *args\n)'
-    expected = syntax + 'x(\n    *args,\n)'
-    assert _fix_src(src, py35_plus=False) == expected
-
-
 @pytest.mark.parametrize(
     ('src', 'expected'),
     (


### PR DESCRIPTION
I decided this wasn't worth it:
- it's a surprising behaviour
- it complicates the code significantly
- there's a maintenance burden each time python adds a new syntax construct
- explicit > implicit