### PR TITLE
Support Windows line endings

### DIFF
--- a/add_trailing_comma.py
+++ b/add_trailing_comma.py
@@ -363,10 +363,12 @@ def _fix_src(contents_text, py35_plus, py36_plus):
 
 
 def fix_file(filename, args):
+    with io.open(filename, 'rb') as f:
+        contents_bytes = f.read()
+
     try:
-        with io.open(filename, 'r', encoding='UTF-8') as f:
-            contents_text_orig = contents_text = f.read()
-    except ValueError:
+        contents_text_orig = contents_text = contents_bytes.decode('UTF-8')
+    except UnicodeDecodeError:
         print('{} is non-utf-8 (not supported)'.format(filename))
         return 1
 
@@ -374,7 +376,7 @@ def fix_file(filename, args):
 
     if contents_text != contents_text_orig:
         print('Rewriting {}'.format(filename))
-        with io.open(filename, 'w', encoding='UTF-8') as f:
+        with io.open(filename, 'w', newlines='', encoding='UTF-8') as f:
             f.write(contents_text)
         return 1
 

--- a/add_trailing_comma.py
+++ b/add_trailing_comma.py
@@ -363,7 +363,7 @@ def _fix_src(contents_text, py35_plus, py36_plus):
 
 
 def fix_file(filename, args):
-    with io.open(filename, 'rb', newline='') as f:
+    with io.open(filename, 'rb') as f:
         contents_bytes = f.read()
 
     try:

--- a/add_trailing_comma.py
+++ b/add_trailing_comma.py
@@ -363,7 +363,7 @@ def _fix_src(contents_text, py35_plus, py36_plus):
 
 
 def fix_file(filename, args):
-    with io.open(filename, 'rb') as f:
+    with open(filename, 'rb') as f:
         contents_bytes = f.read()
 
     try:

--- a/add_trailing_comma.py
+++ b/add_trailing_comma.py
@@ -363,7 +363,7 @@ def _fix_src(contents_text, py35_plus, py36_plus):
 
 
 def fix_file(filename, args):
-    with io.open(filename, 'rb') as f:
+    with io.open(filename, 'rb', newline='') as f:
         contents_bytes = f.read()
 
     try:
@@ -376,7 +376,7 @@ def fix_file(filename, args):
 
     if contents_text != contents_text_orig:
         print('Rewriting {}'.format(filename))
-        with io.open(filename, 'w', newlines='', encoding='UTF-8') as f:
+        with io.open(filename, 'w', newline='', encoding='UTF-8') as f:
             f.write(contents_text)
         return 1
 

--- a/add_trailing_comma.py
+++ b/add_trailing_comma.py
@@ -363,12 +363,10 @@ def _fix_src(contents_text, py35_plus, py36_plus):
 
 
 def fix_file(filename, args):
-    with open(filename, 'rb') as f:
-        contents_bytes = f.read()
-
     try:
-        contents_text_orig = contents_text = contents_bytes.decode('UTF-8')
-    except UnicodeDecodeError:
+        with io.open(filename, 'r', encoding='UTF-8') as f:
+            contents_text_orig = contents_text = f.read()
+    except ValueError:
         print('{} is non-utf-8 (not supported)'.format(filename))
         return 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+    matrix:
+        - TOXENV: py27
+        - TOXENV: py36
+
+install:
+    - "SET PATH=C:\\Python36;C:\\Python36\\Scripts;%PATH%"
+    - pip install tox
+
+# Not a C# project
+build: false
+
+test_script: tox
+
+cache:
+  - '%LOCALAPPDATA%\pip\cache'
+  - '%USERPROFILE%\.pre-commit'

--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -687,6 +687,15 @@ def test_main_changes_a_file(tmpdir, capsys):
     assert f.read() == 'x(\n    1,\n)\n'
 
 
+def test_main_preserves_line_endings(tmpdir, capsys):
+    f = tmpdir.join('f.py')
+    f.write_binary(b'x(\r\n    1\r\n)\r\n')
+    assert main((f.strpath,)) == 1
+    out, _ = capsys.readouterr()
+    assert out == 'Rewriting {}\n'.format(f.strpath)
+    assert f.read_binary() == b'x(\r\n    1,\r\n)\r\n'
+
+
 def test_main_syntax_error(tmpdir):
     f = tmpdir.join('f.py')
     f.write('from __future__ import print_function\nprint 1\n')


### PR DESCRIPTION
Previously, since the file was opened as bytes but written as text, `\r\n` got written as `\r\r\n`, since it read in `\r\n` as bytes, passed through the `\r`, then wrote out `\r\n` as text, which using Python's universal newline support automatically transforms `\n` into `\r\n` on Windows, resulting in `\r\r\n`. Thus, this was adding bunches of `\r` characters every time it was run. This PR fixes that.