### PR TITLE
Also unhug listcomps / dictcomps / setcomps

### DIFF
--- a/add_trailing_comma.py
+++ b/add_trailing_comma.py
@@ -341,11 +341,11 @@ def _fix_src(contents_text, py35_plus, py36_plus):
             add_comma = not func.star_args or py36_plus
             # functions can be treated as calls
             fixes.append((add_comma, _find_call(func, i, tokens)))
-        # Handle parenthesized things
-        elif token.src == '(':
-            fixes.append((False, _find_simple(i, tokens)))
         elif key in visitor.literals:
             fixes.append((True, _find_simple(i, tokens)))
+        # Handle parenthesized things, unhug of tuples, and comprehensions
+        elif token.src in START_BRACES:
+            fixes.append((False, _find_simple(i, tokens)))
 
         for add_comma, fix_data in fixes:
             if fix_data is not None:

--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -577,6 +577,23 @@ def test_noop_unhugs(src):
             '    ], None,\n'
             ')',
         ),
+        # Regression test for #32
+        (
+            '[a()\n'
+            '    for b in c\n'
+            '    if (\n'
+            '        d\n'
+            '    )\n'
+            ']',
+
+            '[\n'
+            '    a()\n'
+            '    for b in c\n'
+            '    if (\n'
+            '        d\n'
+            '    )\n'
+            ']',
+        ),
     ),
 )
 def test_fix_unhugs(src, expected):


### PR DESCRIPTION
Resolves #32

CC @chriskuehl 

I also ran this against Yelp/paasta and the diff looks fine (one minor thing that autopep8 touched up afterwards due to this not being fixed sooner (it would have indented correctly had this fix been in place from the beginning))