### PR TITLE
Add trailing commas for class definitions

### DIFF
--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -750,6 +750,76 @@ def test_fix_from_import(src, expected):
     assert _fix_src(src, py35_plus=False, py36_plus=False) == expected
 
 
+@pytest.mark.parametrize(
+    'src',
+    (
+        'class C: pass',
+        'class C(): pass',
+        'class C(object): pass',
+        'class C(\n'
+        '    object,\n'
+        '): pass',
+    ),
+)
+def test_fix_classes_noop(src):
+    assert _fix_src(src, py35_plus=False, py36_plus=False) == src
+
+
+@pytest.mark.parametrize(
+    ('src', 'expected'),
+    (
+        (
+            'class C(\n'
+            '    object\n'
+            '): pass',
+            'class C(\n'
+            '    object,\n'
+            '): pass',
+        ),
+    ),
+)
+def test_fix_classes(src, expected):
+    assert _fix_src(src, py35_plus=False, py36_plus=False) == expected
+
+
+@xfailif_py2
+@pytest.mark.parametrize(
+    ('src', 'expected'),
+    (
+        (
+            'bases = (object,)\n'
+            'class C(\n'
+            '    *bases\n'
+            '): pass',
+            'bases = (object,)\n'
+            'class C(\n'
+            '    *bases,\n'
+            '): pass',
+        ),
+        (
+            'kws = {"metaclass": type}\n'
+            'class C(\n'
+            '    **kws\n'
+            '): pass',
+            'kws = {"metaclass": type}\n'
+            'class C(\n'
+            '    **kws,\n'
+            '): pass',
+        ),
+        (
+            'class C(\n'
+            '    metaclass=type\n'
+            '): pass',
+            'class C(\n'
+            '    metaclass=type,\n'
+            '): pass',
+        ),
+    ),
+)
+def test_fix_classes_py3_only_syntax(src, expected):
+    assert _fix_src(src, py35_plus=False, py36_plus=False) == expected
+
+
 def test_main_trivial():
     assert main(()) == 0
 


### PR DESCRIPTION
Noticed in #52 