### PR TITLE
Add '-' to read from stdin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage
 flake8
+mock
 pre-commit
 pytest

--- a/tests/add_trailing_comma_test.py
+++ b/tests/add_trailing_comma_test.py
@@ -916,20 +916,16 @@ def test_main_py36_plus_function_trailing_commas(
 
 
 def test_main_stdin_no_changes(capsys):
-    with mock.patch.object(
-        sys, 'stdin',
-        io.TextIOWrapper(io.BytesIO(b'x = 5\n'), 'UTF-8'),
-    ):
+    stdin = io.TextIOWrapper(io.BytesIO(b'x = 5\n'), 'UTF-8')
+    with mock.patch.object(sys, 'stdin', stdin):
         assert main(('-',)) == 0
     out, err = capsys.readouterr()
     assert out == 'x = 5\n'
 
 
 def test_main_stdin_with_changes(capsys):
-    with mock.patch.object(
-        sys, 'stdin',
-        io.TextIOWrapper(io.BytesIO(b'x(\n    1\n)\n'), 'UTF-8'),
-    ):
+    stdin = io.TextIOWrapper(io.BytesIO(b'x(\n    1\n)\n'), 'UTF-8')
+    with mock.patch.object(sys, 'stdin', stdin):
         assert main(('-',)) == 1
     out, err = capsys.readouterr()
     assert out == 'x(\n    1,\n)\n'


### PR DESCRIPTION
Tools like ALE and so forth generally pass the buffer of the editor directly to the tool to edit and expect to read it back on stdout. I've added the - to signal to add-trailing-comma to read data from stdin and output to stdout. Note: this is why I always output the text, regardless of whether it changed. ALE would just wipe the buffer if add-trailing-comma returned nothing.

I modeled this mostly off of tools like black and isort. Black doesn't have any error handling around passing multiple files and -. Black also only briefly mentions it in the docs.

I've also added two basic tests to check that a (mocked) stdin works.