### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -33,7 +33,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.0
     hooks:

--- a/add_trailing_comma/__main__.py
+++ b/add_trailing_comma/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from add_trailing_comma._main import main
 
 if __name__ == '__main__':

--- a/add_trailing_comma/_ast_helpers.py
+++ b/add_trailing_comma/_ast_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import warnings
 

--- a/add_trailing_comma/_data.py
+++ b/add_trailing_comma/_data.py
@@ -1,13 +1,13 @@
+from __future__ import annotations
+
 import ast
 import collections
 import pkgutil
 from typing import Callable
-from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import NamedTuple
 from typing import Tuple
-from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -36,7 +36,7 @@ ASTFunc = Callable[[State, AST_T], Iterable[Tuple[Offset, TokenFunc]]]
 FUNCS = collections.defaultdict(list)
 
 
-def register(tp: Type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
+def register(tp: type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
     def register_decorator(func: ASTFunc[AST_T]) -> ASTFunc[AST_T]:
         FUNCS[tp].append(func)
         return func
@@ -44,14 +44,14 @@ def register(tp: Type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
 
 
 class ASTCallbackMapping(Protocol):
-    def __getitem__(self, tp: Type[AST_T]) -> List[ASTFunc[AST_T]]: ...
+    def __getitem__(self, tp: type[AST_T]) -> list[ASTFunc[AST_T]]: ...
 
 
 def visit(
         funcs: ASTCallbackMapping,
         tree: ast.AST,
         version: Version,
-) -> Dict[Offset, List[TokenFunc]]:
+) -> dict[Offset, list[TokenFunc]]:
     nodes = [(tree, State(min_version=version))]
 
     ret = collections.defaultdict(list)

--- a/add_trailing_comma/_main.py
+++ b/add_trailing_comma/_main.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 import argparse
 import sys
 from typing import Iterable
-from typing import List
-from typing import Optional
 from typing import Sequence
-from typing import Tuple
 
 from tokenize_rt import src_to_tokens
 from tokenize_rt import Token
@@ -18,14 +17,14 @@ from add_trailing_comma._token_helpers import fix_brace
 from add_trailing_comma._token_helpers import START_BRACES
 
 
-def _changing_list(lst: List[Token]) -> Iterable[Tuple[int, Token]]:
+def _changing_list(lst: list[Token]) -> Iterable[tuple[int, Token]]:
     i = 0
     while i < len(lst):
         yield i, lst[i]
         i += 1
 
 
-def _fix_src(contents_text: str, min_version: Tuple[int, ...]) -> str:
+def _fix_src(contents_text: str, min_version: tuple[int, ...]) -> str:
     try:
         ast_obj = ast_parse(contents_text)
     except SyntaxError:
@@ -83,7 +82,7 @@ def fix_file(filename: str, args: argparse.Namespace) -> int:
         return contents_text != contents_text_orig
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')

--- a/add_trailing_comma/_plugins/calls.py
+++ b/add_trailing_comma/_plugins/calls.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -18,10 +17,10 @@ from add_trailing_comma._token_helpers import fix_brace
 
 def _fix_call(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         add_comma: bool,
-        arg_offsets: Set[Offset],
+        arg_offsets: set[Offset],
 ) -> None:
     return fix_brace(
         tokens,
@@ -35,7 +34,7 @@ def _fix_call(
 def visit_Call(
         state: State,
         node: ast.Call,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     argnodes = [*node.args, *node.keywords]
     arg_offsets = set()
     has_starargs = False

--- a/add_trailing_comma/_plugins/classes.py
+++ b/add_trailing_comma/_plugins/classes.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -18,9 +17,9 @@ from add_trailing_comma._token_helpers import fix_brace
 
 def _fix_class(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
-        arg_offsets: Set[Offset],
+        arg_offsets: set[Offset],
 ) -> None:
     fix_brace(
         tokens,
@@ -34,7 +33,7 @@ def _fix_class(
 def visit_ClassDef(
         state: State,
         node: ast.ClassDef,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     # starargs are allowed in py3 class definitions, py35+ allows trailing
     # commas.  py34 does not, but adding an option for this very obscure
     # case seems not worth it.

--- a/add_trailing_comma/_plugins/functions.py
+++ b/add_trailing_comma/_plugins/functions.py
@@ -1,10 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
-from typing import Union
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -19,10 +17,10 @@ from add_trailing_comma._token_helpers import fix_brace
 
 def _fix_func(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         add_comma: bool,
-        arg_offsets: Set[Offset],
+        arg_offsets: set[Offset],
 ) -> None:
     fix_brace(
         tokens,
@@ -34,8 +32,8 @@ def _fix_func(
 
 def visit_FunctionDef(
         state: State,
-        node: Union[ast.AsyncFunctionDef, ast.FunctionDef],
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+        node: ast.AsyncFunctionDef | ast.FunctionDef,
+) -> Iterable[tuple[Offset, TokenFunc]]:
     has_starargs = False
     args = [*getattr(node.args, 'posonlyargs', ()), *node.args.args]
 

--- a/add_trailing_comma/_plugins/imports.py
+++ b/add_trailing_comma/_plugins/imports.py
@@ -1,8 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -16,7 +15,7 @@ from add_trailing_comma._token_helpers import Fix
 from add_trailing_comma._token_helpers import fix_brace
 
 
-def _find_import(i: int, tokens: List[Token]) -> Optional[Fix]:
+def _find_import(i: int, tokens: list[Token]) -> Fix | None:
     # progress forwards until we find either a `(` or a newline
     for i in range(i, len(tokens)):
         token = tokens[i]
@@ -28,7 +27,7 @@ def _find_import(i: int, tokens: List[Token]) -> Optional[Fix]:
         raise AssertionError('Past end?')
 
 
-def _fix_import(i: int, tokens: List[Token]) -> None:
+def _fix_import(i: int, tokens: list[Token]) -> None:
     fix_brace(
         tokens,
         _find_import(i, tokens),
@@ -41,5 +40,5 @@ def _fix_import(i: int, tokens: List[Token]) -> None:
 def visit_ImportFrom(
         state: State,
         node: ast.ImportFrom,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     yield ast_to_offset(node), _fix_import

--- a/add_trailing_comma/_plugins/literals.py
+++ b/add_trailing_comma/_plugins/literals.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 import ast
 import functools
 import sys
 from typing import Iterable
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import Offset
@@ -21,7 +20,7 @@ from add_trailing_comma._token_helpers import fix_brace
 
 def _fix_literal(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         one_el_tuple: bool,
 ) -> None:
@@ -36,7 +35,7 @@ def _fix_literal(
 def visit_Set(
         state: State,
         node: ast.Set,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     func = functools.partial(_fix_literal, one_el_tuple=False)
     yield ast_to_offset(node), func
 
@@ -45,7 +44,7 @@ def visit_Set(
 def visit_List(
         state: State,
         node: ast.List,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if node.elts:
         func = functools.partial(_fix_literal, one_el_tuple=False)
         yield ast_to_offset(node), func
@@ -55,13 +54,13 @@ def visit_List(
 def visit_Dict(
         state: State,
         node: ast.Dict,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if node.values:
         func = functools.partial(_fix_literal, one_el_tuple=False)
         yield ast_to_offset(node), func
 
 
-def _find_tuple(i: int, tokens: List[Token]) -> Optional[Fix]:
+def _find_tuple(i: int, tokens: list[Token]) -> Fix | None:
     # tuples are evil, we need to backtrack to find the opening paren
     i -= 1
     while tokens[i].name in NON_CODING_TOKENS:
@@ -76,7 +75,7 @@ def _find_tuple(i: int, tokens: List[Token]) -> Optional[Fix]:
 
 def _fix_tuple(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         one_el_tuple: bool,
 ) -> None:
@@ -90,7 +89,7 @@ def _fix_tuple(
 
 def _fix_tuple_py38(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         one_el_tuple: bool,
 ) -> None:  # pragma: >=3.8 cover
@@ -112,7 +111,7 @@ def _fix_tuple_py38(
 def visit_Tuple(
         state: State,
         node: ast.Tuple,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if node.elts:
         is_one_el = len(node.elts) == 1
         if (

--- a/add_trailing_comma/_plugins/match.py
+++ b/add_trailing_comma/_plugins/match.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 import ast
 import functools
 import sys
 from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -21,9 +20,9 @@ from add_trailing_comma._token_helpers import fix_brace
 if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     def _fix_match_class(
             i: int,
-            tokens: List[Token],
+            tokens: list[Token],
             *,
-            arg_offsets: Set[Offset],
+            arg_offsets: set[Offset],
     ) -> None:
         return fix_brace(
             tokens,
@@ -36,13 +35,13 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     def visit_MatchClass(
             state: State,
             node: ast.MatchClass,
-    ) -> Iterable[Tuple[Offset, TokenFunc]]:
+    ) -> Iterable[tuple[Offset, TokenFunc]]:
         arg_offsets = {ast_to_offset(pat) for pat in node.patterns}
         arg_offsets |= {ast_to_offset(pat) for pat in node.kwd_patterns}
         func = functools.partial(_fix_match_class, arg_offsets=arg_offsets)
         yield ast_to_offset(node), func
 
-    def _fix_mapping(i: int, tokens: List[Token]) -> None:
+    def _fix_mapping(i: int, tokens: list[Token]) -> None:
         fix_brace(
             tokens,
             find_simple(i, tokens),
@@ -50,7 +49,7 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
             remove_comma=True,
         )
 
-    def _fix_sequence(i: int, tokens: List[Token], *, n: int) -> None:
+    def _fix_sequence(i: int, tokens: list[Token], *, n: int) -> None:
         remove_comma = tokens[i].src == '[' or n > 1
         fix_brace(
             tokens,
@@ -63,13 +62,13 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     def visit_MatchMapping(
             state: State,
             node: ast.MatchClass,
-    ) -> Iterable[Tuple[Offset, TokenFunc]]:
+    ) -> Iterable[tuple[Offset, TokenFunc]]:
         yield ast_to_offset(node), _fix_mapping
 
     @register(ast.MatchSequence)
     def visit_MatchSequence(
             state: State,
             node: ast.MatchClass,
-    ) -> Iterable[Tuple[Offset, TokenFunc]]:
+    ) -> Iterable[tuple[Offset, TokenFunc]]:
         func = functools.partial(_fix_sequence, n=len(node.patterns))
         yield ast_to_offset(node), func

--- a/add_trailing_comma/_token_helpers.py
+++ b/add_trailing_comma/_token_helpers.py
@@ -1,8 +1,6 @@
-from typing import List
+from __future__ import annotations
+
 from typing import NamedTuple
-from typing import Optional
-from typing import Set
-from typing import Tuple
 
 from tokenize_rt import ESCAPED_NL
 from tokenize_rt import NON_CODING_TOKENS
@@ -17,13 +15,13 @@ END_BRACES = frozenset((')', '}', ']'))
 
 
 class Fix(NamedTuple):
-    braces: Tuple[int, int]
+    braces: tuple[int, int]
     multi_arg: bool
     remove_comma: bool
     initial_indent: int
 
 
-def find_simple(first_brace: int, tokens: List[Token]) -> Optional[Fix]:
+def find_simple(first_brace: int, tokens: list[Token]) -> Fix | None:
     brace_stack = [first_brace]
     multi_arg = False
 
@@ -77,10 +75,10 @@ def find_simple(first_brace: int, tokens: List[Token]) -> Optional[Fix]:
 
 
 def find_call(
-        arg_offsets: Set[Offset],
+        arg_offsets: set[Offset],
         i: int,
-        tokens: List[Token],
-) -> Optional[Fix]:
+        tokens: list[Token],
+) -> Fix | None:
     # When we get a `call` object, the ast refers to it as this:
     #
     #     func_name(arg, arg, arg)
@@ -113,8 +111,8 @@ def find_call(
 
 
 def fix_brace(
-        tokens: List[Token],
-        fix_data: Optional[Fix],
+        tokens: list[Token],
+        fix_data: Fix | None,
         add_comma: bool,
         remove_comma: bool,
 ) -> None:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,5 +19,5 @@ jobs:
     os: windows
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38, py39, py310]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 packages = find:
 install_requires =
     tokenize-rt>=3.0.1
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/features/align_braces_test.py
+++ b/tests/features/align_braces_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from add_trailing_comma._main import _fix_src

--- a/tests/features/calls_test.py
+++ b/tests/features/calls_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 
 import pytest

--- a/tests/features/classes_test.py
+++ b/tests/features/classes_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from add_trailing_comma._main import _fix_src

--- a/tests/features/functions_test.py
+++ b/tests/features/functions_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/features/imports_test.py
+++ b/tests/features/imports_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from add_trailing_comma._main import _fix_src

--- a/tests/features/literals_test.py
+++ b/tests/features/literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from add_trailing_comma._main import _fix_src

--- a/tests/features/match_test.py
+++ b/tests/features/match_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/features/remove_commas_test.py
+++ b/tests/features/remove_commas_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from add_trailing_comma._main import _fix_src

--- a/tests/features/unhug_test.py
+++ b/tests/features/unhug_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from add_trailing_comma._main import _fix_src

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import sys
 from unittest import mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pypy3,pre-commit
+envlist = py37,py38,py39,py310,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos